### PR TITLE
added support for beast1 trees

### DIFF
--- a/R/beast.R
+++ b/R/beast.R
@@ -187,6 +187,10 @@ read.stats_beast_internal <- function(beast, tree) {
 
     ## stats <- unlist(strsplit(tree, "\\["))[-1]
     ## stats <- sub(":.+$", "", stats
+    
+    ## BEAST1 edge stat fix
+   	tree <- gsub("\\]:\\[&(.+?\\])", ",\\1:", tree)
+	tree <- gsub(":(\\[.+?\\])", "\\1:", tree)
 
     if (grepl("\\]:[0-9\\.eE+\\-]*\\[", tree) || grepl("\\]\\[", tree)) {
         ## MrBayes output


### PR DESCRIPTION
BEAST1 trees have a separate annotation (`[]` block) for edge statistics. I have added a simple `gsub` to move these edge statistic into the child node's `[]` block. Should be checked to make sure it doesn't break BEAST2 or MrBayes input.