### PR TITLE
fixed a bug in as.phylo.phylo4

### DIFF
--- a/R/method-as-phylo.R
+++ b/R/method-as-phylo.R
@@ -8,9 +8,10 @@ ape::as.phylo
 ##' @export
 as.phylo.phylo4 <- function(x, ...) {
     edge <- x@edge
-    edge <- edge[edge[,1] != 0, ]
+    edge.filter <- edge[,1] != 0
+    edge <- edge[edge.filter, ]
     edge.length <- x@edge.length
-    edge.length <- edge.length[!is.na(edge.length)]
+    edge.length <- edge.length[edge.filter]
     tip.id <- sort(setdiff(edge[,2], edge[,1]))
     tip.label <- x@label[tip.id]
     phylo <- list(edge = edge,


### PR DESCRIPTION
The edge.length variable had the wrong length. Was giving the following error when trying to plot phylo4d objects:

```Error in `$<-.data.frame`(`*tmp*`, branch.length, value = c(0, 2203.70191871662,  : 
  replacement has 251 rows, data has 250```

Have not tested on phylo4 objects.