### PR TITLE
fixed issue with levels_back = 0 and misgrouping when numeric node given in tree_subset

### DIFF
--- a/R/tree-subset.R
+++ b/R/tree-subset.R
@@ -184,14 +184,6 @@ tree_subset.treedata <- function(tree, node, levels_back = 5, group_node = TRUE)
   }
 
 
-  # subset_labels <- tidytree::ancestor(tree_df, node) %>%
-  #   tail(levels_back) %>%
-  #   head(1) %>%
-  #   dplyr::pull(node) %>%
-  #   tidytree::offspring(tree_df, .) %>%
-  #   dplyr::filter(!node %in% parent) %>%
-  #   dplyr::pull(!!quo("label"))
-
   subset_nodes <- which(tree@phylo$tip.label %in% subset_labels)
 
   subtree <- drop.tip(tree, tree@phylo$tip.label[-subset_nodes], rooted = TRUE)

--- a/R/tree-subset.R
+++ b/R/tree-subset.R
@@ -67,6 +67,29 @@ tree_subset.phylo <- function(tree, node, levels_back = 5, group_node = TRUE){
 
     tree_df <- tidytree::as_data_frame(tree)
 
+    selected_node <- node
+
+    is_tip <- tree_df %>%
+      dplyr::mutate(isTip = !node %in% parent) %>%
+      dplyr::filter(node == selected_node | label == selected_node) %>%
+      dplyr::pull(isTip)
+
+    if (is_tip & levels_back == 0){
+      stop("The selected node (", selected_node, ") is a tip. 'levels_back' must be > 0",
+           call. = FALSE)
+    }
+
+    if (is_tip) {
+      group_labels <- tree_df %>%
+        dplyr::filter(node == selected_node | label == selected_node) %>%
+        dplyr::pull(!!quo("label"))
+    } else {
+      group_labels <- tree_df %>%
+        tidytree::offspring(selected_node) %>%
+        dplyr::filter(!node %in% parent) %>%
+        dplyr::pull(!!quo("label"))
+    }
+
     ## This pipeline returns the tip labels of all nodes related to
     ## the specified node
     ##
@@ -77,14 +100,22 @@ tree_subset.phylo <- function(tree, node, levels_back = 5, group_node = TRUE){
     ## It then finds all of the offspring of that parent node. From there
     ## it filters to include only tip and then pulls the labels.
 
-
-    subset_labels <- tidytree::ancestor(tree_df, node) %>%
+    if (levels_back == 0) {
+      subset_labels <- tidytree::offspring(tree_df, selected_node) %>%
+        dplyr::filter(!node %in% parent) %>%
+        dplyr::pull(!!quo("label"))
+    } else {
+      subset_labels <- tidytree::ancestor(tree_df, selected_node) %>%
         tail(levels_back) %>%
         head(1) %>%
         dplyr::pull(node) %>%
         tidytree::offspring(tree_df, .) %>%
         dplyr::filter(!node %in% parent) %>%
         dplyr::pull(!!quo("label"))
+    }
+
+
+
 
     ## This finds the nodes associated with the labels pulled
     subset_nodes <- which(tree$tip.label %in% subset_labels)
@@ -93,7 +124,7 @@ tree_subset.phylo <- function(tree, node, levels_back = 5, group_node = TRUE){
     ## This drops all of the tips that are not included in group_nodes
     subtree <- drop.tip(tree, tree$tip.label[-subset_nodes], rooted = TRUE)
 
-    if (group_node) subtree <- groupOTU.phylo(subtree, .node = node)
+    if (group_node) subtree <- groupOTU.phylo(subtree, .node = group_labels)
 
 
     return(subtree)
@@ -115,20 +146,57 @@ tree_subset.treedata <- function(tree, node, levels_back = 5, group_node = TRUE)
 
   tree_df <- tidytree::as_data_frame(tree)
 
+  selected_node <- node
 
-  subset_labels <- tidytree::ancestor(tree_df, node) %>%
-    tail(levels_back) %>%
-    head(1) %>%
-    dplyr::pull(node) %>%
-    tidytree::offspring(tree_df, .) %>%
-    dplyr::filter(!node %in% parent) %>%
-    dplyr::pull(!!quo("label"))
+  is_tip <- tree_df %>%
+    dplyr::mutate(isTip = !node %in% parent) %>%
+    dplyr::filter(node == selected_node | label == selected_node) %>%
+    dplyr::pull(isTip)
+
+  if (is_tip & levels_back == 0){
+    stop("The selected node (", selected_node, ") is a tip. 'levels_back' must be > 0",
+         call. = FALSE)
+  }
+
+  if (is_tip) {
+    group_labels <- tree_df %>%
+      dplyr::filter(node == selected_node | label == selected_node) %>%
+      dplyr::pull(!!quo("label"))
+  } else {
+    group_labels <- tree_df %>%
+      tidytree::offspring(selected_node) %>%
+      dplyr::filter(!node %in% parent) %>%
+      dplyr::pull(!!quo("label"))
+  }
+
+  if (levels_back == 0) {
+    subset_labels <- tidytree::offspring(tree_df, selected_node) %>%
+      dplyr::filter(!node %in% parent) %>%
+      dplyr::pull(!!quo("label"))
+  } else {
+    subset_labels <- tidytree::ancestor(tree_df, selected_node) %>%
+      tail(levels_back) %>%
+      head(1) %>%
+      dplyr::pull(node) %>%
+      tidytree::offspring(tree_df, .) %>%
+      dplyr::filter(!node %in% parent) %>%
+      dplyr::pull(!!quo("label"))
+  }
+
+
+  # subset_labels <- tidytree::ancestor(tree_df, node) %>%
+  #   tail(levels_back) %>%
+  #   head(1) %>%
+  #   dplyr::pull(node) %>%
+  #   tidytree::offspring(tree_df, .) %>%
+  #   dplyr::filter(!node %in% parent) %>%
+  #   dplyr::pull(!!quo("label"))
 
   subset_nodes <- which(tree@phylo$tip.label %in% subset_labels)
 
   subtree <- drop.tip(tree, tree@phylo$tip.label[-subset_nodes], rooted = TRUE)
 
-  if (group_node) subtree <- groupOTU(subtree, node)
+  if (group_node) subtree <- groupOTU(subtree, group_labels)
 
   return(subtree)
 

--- a/tests/testthat/test-tree-subset.R
+++ b/tests/testthat/test-tree-subset.R
@@ -48,7 +48,36 @@ test_that("bi_tree and named_bi_tree return expected subsets", {
                  dplyr::select(-group),
                as_data_frame(bi_tree))
 
+
+  # testing that levels_back = 0 returns an error when a tip is specified and
+  # a subset tree when a node is specified.
+  expect_error(tree_subset(bi_tree, "t5", levels_back = 0))
+
+  node_zero <- tree_subset(bi_tree, 17, levels_back = 0, group_node = FALSE) %>%
+    as_data_frame() %>%
+    dplyr::filter(!node %in% parent) %>%
+    dplyr::pull(label)
+
+  node_zero_reference <- bi_tree %>%
+    as_data_frame() %>%
+    offspring(17) %>%
+    dplyr::filter(!node %in% parent) %>%
+    dplyr::pull(label)
+
+  expect_true(all(node_zero %in% node_zero_reference))
+  expect_true(all(node_zero_reference %in% node_zero))
+
+
+  # testing that specifying the node by either label or node number returns
+  # the same result - including grouping
+  subset_by_label <- tree_subset(bi_tree, "t7", levels_back = 2)
+  subset_by_node <- tree_subset(bi_tree, 7, levels_back = 2)
+
+  expect_identical(subset_by_label, subset_by_node)
+
+
 })
+
 
 
 test_that("multi_tree and named_multi_tree return expected subtrees", {
@@ -76,6 +105,32 @@ test_that("multi_tree and named_multi_tree return expected subtrees", {
                  as_data_frame() %>%
                  dplyr::select(-group),
                as_data_frame(multi_tree))
+
+  # testing that levels_back = 0 returns an error when a tip is specified and
+  # a subset tree when a node is specified.
+  expect_error(tree_subset(multi_tree, "t5", levels_back = 0))
+
+  node_zero <- tree_subset(multi_tree, 13, levels_back = 0, group_node = FALSE) %>%
+    as_data_frame() %>%
+    dplyr::filter(!node %in% parent) %>%
+    dplyr::pull(label)
+
+  node_zero_reference <- multi_tree %>%
+    as_data_frame() %>%
+    offspring(13) %>%
+    dplyr::filter(!node %in% parent) %>%
+    dplyr::pull(label)
+
+  expect_true(all(node_zero %in% node_zero_reference))
+  expect_true(all(node_zero_reference %in% node_zero))
+
+
+  # testing that specifying the node by either label or node number returns
+  # the same result - including grouping
+  subset_by_label <- tree_subset(multi_tree, "t5", levels_back = 2)
+  subset_by_node <- tree_subset(multi_tree, 5, levels_back = 2)
+
+  expect_identical(subset_by_label, subset_by_node)
 })
 
 
@@ -89,7 +144,7 @@ beast_tree <- read.beast(beast_file)
 codeml_tree <- read.codeml(rst_file, mlc_file)
 
 merged_tree <- merge_tree(beast_tree, codeml_tree)
-merged_tree
+
 
 
 test_that("treedata returns expected results", {
@@ -118,4 +173,31 @@ test_that("treedata returns expected results", {
 
   expect_identical(merged_subset_df$value_subset, merged_subset_df$value_orig)
   expect_identical(merged_subset_df$branch.length.x, merged_subset_df$branch.length.y)
+
+
+  # testing that levels_back = 0 returns an error when a tip is specified and
+  # a subset tree when a node is specified.
+  expect_error(tree_subset(merged_tree, "A/New_York/334/2004", levels_back = 0))
+
+  node_zero <- tree_subset(merged_tree, 122, levels_back = 0, group_node = FALSE) %>%
+    as_data_frame() %>%
+    dplyr::filter(!node %in% parent) %>%
+    dplyr::pull(label)
+
+  node_zero_reference <- merged_tree %>%
+    as_data_frame() %>%
+    offspring(122) %>%
+    dplyr::filter(!node %in% parent) %>%
+    dplyr::pull(label)
+
+  expect_true(all(node_zero %in% node_zero_reference))
+  expect_true(all(node_zero_reference %in% node_zero))
+
+
+  # testing that specifying the node by either label or node number returns
+  # the same result - including grouping
+  subset_by_label <- tree_subset(merged_tree, "A/New_York/238/2005", levels_back = 2)
+  subset_by_node <- tree_subset(merged_tree, 5, levels_back = 2)
+
+  expect_identical(subset_by_label, subset_by_node)
 })


### PR DESCRIPTION
I received an email this past week regarding an issue with the `tree_subset` function. This is the main portion of the email:

> I'm running into a problem where I can specify a node (rather than tip) with tree_subset, but can't return the tree containing the specified node alone.  levels_back for any number > 0 works nicely, but levels_back=0 returns the original tree object.

So the issue was that when `levels_back` is set to 0, the function just returns the full tree rather than all of the offspring of the selected node. I think that this would be a useful feature for the `tree_subset` function when subsetting by node rather than tip. So I have implemented a fix for this. If `levels_back = 0` and a node is given, then the tree is subset to include only the offspring of the specified node. If `levels_back = 0` and a tip is given, an error is returned since it has no offspring.  If you have a different desired outcome for that scenario, I am happy to change it. 

While looking into this issue, I noticed another issue with how grouping took place when a node/tip was specified by its numeric input, rather than the label. The tree was being subset correctly, but the grouping was being applied to the subset tree and the numeric value of the tip is no longer the same as it was in the original tree. To fix this, I added some logic that will find the labels of the specified node so that it will group the correct tips. 

Finally, I changed the behavior of grouping when a node is specified instead of a tip. Previously, the grouping wasn't really working if a node was given. Now, if a node is selected, rather than a tip, all of the nodes offspring are grouped. 

I added tests to the test-tree-subset.R file for these things. 


Here is a `reprex` showing the changes:

``` r
library(treeio)
library(ggplot2)
library(ggtree)
#> ggtree v1.12.6  For help: https://guangchuangyu.github.io/software/ggtree
#> 
#> If you use ggtree in published research, please cite:
#> Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution 2017, 8(1):28-36, doi:10.1111/2041-210X.12628
library(ape)
#> 
#> Attaching package: 'ape'
#> The following object is masked from 'package:ggtree':
#> 
#>     rotate
#> The following object is masked from 'package:treeio':
#> 
#>     drop.tip
library(tidytree)
#> 
#> Attaching package: 'tidytree'
#> The following object is masked from 'package:ggtree':
#> 
#>     MRCA
#> The following object is masked from 'package:stats':
#> 
#>     filter

set.seed(42)

# example with a phylo object
bi_tree <- ape::rtree(10)
bi_tree$tip.label <- paste0("t", 1:10)
bi_tree$node.label <- paste0("n", 11:19)

# original tree 
bi_tree %>% 
  ggtree() + 
  geom_tiplab() +
  geom_nodelab()
```

![](https://i.imgur.com/X8ciigc.png)

``` r
# levels_back = 0

# tip given - returns error
bi_tree %>% 
  tree_subset("t5", levels_back = 0)
#> Error: The selected node (t5) is a tip. 'levels_back' must be > 0

# node given - returns tree of offspring
bi_tree %>% 
  tree_subset("n16", levels_back = 0) %>% 
  ggtree() + 
  geom_tiplab() + 
  geom_nodelab()
```

![](https://i.imgur.com/lEteWg3.png)

``` r
# giving node by label or node number

# when tip given
identical(
  tree_subset(bi_tree, "t5", levels_back = 2),
  tree_subset(bi_tree, 5, levels_back = 2)
)
#> [1] TRUE

# when node given
identical(
  tree_subset(bi_tree, "n17", levels_back = 1),
  tree_subset(bi_tree, 17, levels_back = 1)
)
#> [1] TRUE
```

``` r
# grouping when node specified
bi_tree %>% 
  tree_subset("n17", levels_back = 2) %>% 
  ggtree(aes(color = group)) + 
  geom_tiplab() + 
  geom_nodelab() +
  scale_color_manual(values = c(`1` = "red", `0` = "black"))
```

![](https://i.imgur.com/Yi3DYkc.png)

Created on 2018-08-27 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).

