### PR TITLE
Remove rd warning by separating the line

### DIFF
--- a/R/ASTRAL.R
+++ b/R/ASTRAL.R
@@ -7,7 +7,11 @@
 ##' @export
 ##' @author Guangchuang Yu
 ##' @examples
-##' tt <- "((species1,(species2,species3)'[pp1=0.75;pp2=0.24;pp3=0.01]':1.2003685744180805)'[pp1=0.98;pp2=0.02;pp3=0]':0.9679599282730038,((species4,species5)'[pp1=0.88;pp2=0.11;pp3=0.01]':1.2454851536484994))"
+##' tt <- paste0(
+##'   "((species1,(species2,species3)'[pp1=0.75;pp2=0.24;pp3=0.01]':",
+##'   "1.2003685744180805)'[pp1=0.98;pp2=0.02;pp3=0]':0.9679599282730038,",
+##'   "((species4,species5)'[pp1=0.88;pp2=0.11;pp3=0.01]':1.2454851536484994))"
+##' )
 ##' read.astral(textConnection(tt))
 read.astral <- function(file) {
     treetext <- readLines(file, warn=FALSE)

--- a/man/read.astral.Rd
+++ b/man/read.astral.Rd
@@ -16,7 +16,11 @@ treedata object
 parse ASTRAL output newick text
 }
 \examples{
-tt <- "((species1,(species2,species3)'[pp1=0.75;pp2=0.24;pp3=0.01]':1.2003685744180805)'[pp1=0.98;pp2=0.02;pp3=0]':0.9679599282730038,((species4,species5)'[pp1=0.88;pp2=0.11;pp3=0.01]':1.2454851536484994))"
+tt <- paste0(
+  "((species1,(species2,species3)'[pp1=0.75;pp2=0.24;pp3=0.01]':",
+  "1.2003685744180805)'[pp1=0.98;pp2=0.02;pp3=0]':0.9679599282730038,",
+  "((species4,species5)'[pp1=0.88;pp2=0.11;pp3=0.01]':1.2454851536484994))"
+)
 read.astral(textConnection(tt))
 }
 \author{


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

The long line is separated into multiple strings and concatenated with `paste0()`.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example

```
❯ checking Rd line widths ... NOTE
  Rd file 'read.astral.Rd':
    \examples lines wider than 100 characters:
       tt <- "((species1,(species2,species3)'[pp1=0.75;pp2=0.24;pp3=0.01]':1.2003685744180805)'[pp1=0.98;pp2=0.02;pp3=0]':0.9679599282730038,( ... [TRUNCATED]

  These lines will be truncated in the PDF manual.

0 errors ✔ | 0 warnings ✔ | 1 note ✖
```