### PR TITLE
update read.raxml

### DIFF
--- a/R/RAxML.R
+++ b/R/RAxML.R
@@ -14,8 +14,9 @@ read.raxml <- function(file) {
     tree_text <- gsub('(:[0-9\\.eE+\\-]+)\\[(\\d+)\\]', '\\@\\2\\1', tree.text)
     phylo <- read.tree(text=tree_text)
     if(any(grepl('@', phylo$node.label))) {
-        bootstrap <- as.numeric(gsub("[^@]*@(\\d+)", "\\1", phylo$node.label)) %>%
-                     suppressWarnings()
+        bootstrap <- suppressWarnings(
+            as.numeric(gsub("[^@]*@(\\d+)", "\\1", phylo$node.label)) 
+                   )
         phylo$node.label <- gsub("@\\d+", "", phylo$node.label)
     }
 


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
update `read.raxml` to avoid generating the warning messages.
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
if some nodes of raxml tree do not have bootstrap value, it will generate warning messages 

like this

```
> library(treeio)
treeio v1.16.2  For help: https://yulab-smu.top/treedata-book/

If you use treeio in published research, please cite:

LG Wang, TTY Lam, S Xu, Z Dai, L Zhou, T Feng, P Guo, CW Dunn, BR Jones, T Bradley, H Zhu, Y Guan, Y Jiang, G Yu. treeio: an R package for phylogenetic tree input and output with richly annotated and associated data. Molecular Biology and Evolution 2020, 37(2):599-603. doi: 10.1093/molbev/msz240

> tre <- read.raxml("./treedata-book/data/tree_boots.nwk")
Warning messages:
1: In readLines(file) :
  incomplete final line found on './treedata-book/data/tree_boots.nwk'
2: In read.raxml("./treedata-book/data/tree_boots.nwk") :
  NAs introduced by coercion
>
```
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

+ suppress the warning message

```
> library(treeio)
treeio v1.17.2  For help: https://yulab-smu.top/treedata-book/

If you use treeio in published research, please cite:

LG Wang, TTY Lam, S Xu, Z Dai, L Zhou, T Feng, P Guo, CW Dunn, BR Jones, T Bradley, H Zhu, Y Guan, Y Jiang, G Yu. treeio: an R package for phylogenetic tree input and output with richly annotated and associated data. Molecular Biology and Evolution 2020, 37(2):599-603. doi: 10.1093/molbev/msz240

> tr <- read.raxml("./treedata-book/data/tree_boots.nwk")
> tr
'treedata' S4 object that stored information of
        './treedata-book/data/tree_boots.nwk'.

...@ phylo:

Phylogenetic tree with 7 tips and 6 internal nodes.

Tip labels:
  Rangifer_tarandus, Cervus_elaphus, Bos_taurus, Ovis_orientalis, Suricata_suricatta, Cystophora_cristata, ...
Node labels:
  Mammalia, Artiodactyla, Cervidae, Bovidae, Carnivora, Caniformia

Rooted; includes branch lengths.

with the following features available:
        'bootstrap'.

# The associated data tibble abstraction: 13 × 4
# The 'node', 'label' and 'isTip' are from the phylo tree.
    node label               isTip bootstrap
   <int> <chr>               <lgl>     <dbl>
 1     1 Rangifer_tarandus   TRUE         NA
 2     2 Cervus_elaphus      TRUE         NA
 3     3 Bos_taurus          TRUE         NA
 4     4 Ovis_orientalis     TRUE         NA
 5     5 Suricata_suricatta  TRUE         NA
 6     6 Cystophora_cristata TRUE         NA
 7     7 Mephitis_mephitis   TRUE         NA
 8     8 Mammalia            FALSE        NA
 9     9 Artiodactyla        FALSE        92
10    10 Cervidae            FALSE        98
11    11 Bovidae             FALSE        99
12    12 Carnivora           FALSE        96
13    13 Caniformia          FALSE        98
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

