### PR TITLE
suppress the warning message about check whether is a tbl_tree

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -126,13 +126,15 @@ has.slot <- function(object, slotName) {
 }
 
 build_new_labels <- function(tree){
-    node2label_old <- tree %>% as_tibble() %>% dplyr::select(c("node", "label")) 
+    node2label_old <- tree %>% as_tibble() %>% dplyr::select(c("node", "label")) %>%
+      suppressMessages() 
     if (inherits(tree, "treedata")){
         tree <- tree@phylo
     }
     tree$tip.label <- paste0("t", seq_len(Ntip(tree)))
     tree$node.label <- paste0("n", seq_len(Nnode(tree)))
-    node2label_new <- tree %>% as_tibble() %>% dplyr::select(c("node", "label")) 
+    node2label_new <- tree %>% as_tibble() %>% dplyr::select(c("node", "label")) %>%
+       suppressMessages() 
     old_and_new <- node2label_old %>% 
                    dplyr::inner_join(node2label_new, by="node") %>%
                    dplyr::rename(old="label.x", new="label.y") 
@@ -143,9 +145,11 @@ build_new_tree <- function(tree, node2old_new_lab){
     # replace new label with old label
     treeda <- tree %>% as_tibble()
     treeda1 <- treeda %>%
-               dplyr::filter(.data$label %in% node2old_new_lab$new)
+               dplyr::filter(.data$label %in% node2old_new_lab$new) %>%
+               suppressWarnings()
     treeda2 <- treeda %>%
-               dplyr::filter(!(.data$label %in% node2old_new_lab$new))
+               dplyr::filter(!(.data$label %in% node2old_new_lab$new)) %>%
+               suppressWarnings()
     # original label
     treeda1$label <- node2old_new_lab[match(treeda1$label, node2old_new_lab$new), "old"] %>%
                      unlist(use.names=FALSE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,6 +3,7 @@ globalVariables(".")
 
 ##' @importFrom utils packageDescription
 .onAttach <- function(libname, pkgname) {
+    options(check.tbl_tree.verbose=FALSE)
     pkgVersion <- packageDescription(pkgname, fields="Version")
     ref <- random_ref(pkgname = pkgname, pkgVersion = pkgVersion, random_n = 2)
     if (!is.null(ref)) packageStartupMessage(ref)


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

using `options(check.tbl_tree.verbose=FALSE)` to suppress the warning message of check whether is a tbl_tree.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

https://github.com/YuLab-SMU/tidytree/issues/40

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
### Before

```
> library(treeio)
treeio v1.25.1.002 For help:
https://yulab-smu.top/treedata-book/

If you use the ggtree package suite in published research, please cite
the appropriate paper(s):

LG Wang, TTY Lam, S Xu, Z Dai, L Zhou, T Feng, P Guo, CW Dunn, BR
Jones, T Bradley, H Zhu, Y Guan, Y Jiang, G Yu. treeio: an R package
for phylogenetic tree input and output with richly annotated and
associated data. Molecular Biology and Evolution. 2020, 37(2):599-603.
doi: 10.1093/molbev/msz240

G Yu. Data Integration, Manipulation and Visualization of Phylogenetic
Trees (1st ed.). Chapman and Hall/CRC. 2022. ISBN: 9781032233574

Shuangbin Xu, Lin Li, Xiao Luo, Meijun Chen, Wenli Tang, Li Zhan, Zehan
Dai, Tommy T. Lam, Yi Guan, Guangchuang Yu. Ggtree: A serialized data
object for visualization of a phylogenetic tree and annotation data.
iMeta 2022, 1(4):e56. doi:10.1002/imt2.56
> example(drop.tip)

drp.tp> nhxfile <- system.file("extdata/NHX", "ADH.nhx", package="treeio")

drp.tp> nhx <- read.nhx(nhxfile)

drp.tp> tr1 <- drop.tip(nhx, c("ADH2", "ADH1"))
ℹ invalid tbl_tree object. Missing column: parent.
ℹ invalid tbl_tree object. Missing column: parent.
! # Invaild edge matrix for <phylo>. A <tbl_df> is returned.

drp.tp> tr2 <- keep.tip(nhx, c("ADH2", "ADH1"))
ℹ invalid tbl_tree object. Missing column: parent.
ℹ invalid tbl_tree object. Missing column: parent.
! # Invaild edge matrix for <phylo>. A <tbl_df> is returned.
>
```

### After

```
> library(treeio)
treeio v1.25.1.002 For help:
https://yulab-smu.top/treedata-book/

If you use the ggtree package suite in published research, please cite
the appropriate paper(s):

LG Wang, TTY Lam, S Xu, Z Dai, L Zhou, T Feng, P Guo, CW Dunn, BR
Jones, T Bradley, H Zhu, Y Guan, Y Jiang, G Yu. treeio: an R package
for phylogenetic tree input and output with richly annotated and
associated data. Molecular Biology and Evolution. 2020, 37(2):599-603.
doi: 10.1093/molbev/msz240

Guangchuang Yu.  Data Integration, Manipulation and Visualization of
Phylogenetic Trees (1st edition). Chapman and Hall/CRC. 2022,
doi:10.1201/9781003279242

S Xu, Z Dai, P Guo, X Fu, S Liu, L Zhou, W Tang, T Feng, M Chen, L
Zhan, T Wu, E Hu, Y Jiang, X Bo, G Yu. ggtreeExtra: Compact
visualization of richly annotated phylogenetic data. Molecular Biology
and Evolution. 2021, 38(9):4039-4042. doi: 10.1093/molbev/msab166
> example(drop.tip)

drp.tp> nhxfile <- system.file("extdata/NHX", "ADH.nhx", package="treeio")

drp.tp> nhx <- read.nhx(nhxfile)

drp.tp> tr1 <- drop.tip(nhx, c("ADH2", "ADH1"))

drp.tp> tr2 <- keep.tip(nhx, c("ADH2", "ADH1"))
>
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

