### PR TITLE
fix issue when beast file contain negative branch

### DIFF
--- a/R/beast.R
+++ b/R/beast.R
@@ -194,7 +194,7 @@ read.stats_beast_internal <- function(beast, tree) {
         # t1:0.04[&mutation="test1"] -> t1[&mutation="test1"]:0.04
         # or t1[&prob=100]:0.04[&mutation="test"] -> t1[&prob=100][&mutation="test"]:0.04 (MrBayes output)
         # pattern <- "(\\w+)?(:?\\d*\\.?\\d*[Ee]?[\\+\\-]?\\d*)?(\\[&.*?\\])"
-        pattern <- "(\\w+)?(:\\d*\\.?\\d*[Ee]?[\\+\\-]?\\L*\\d*)?(\\[&.*?\\])"
+        pattern <- "(\\w+)?(:[\\+\\-]?\\d*\\.?\\d*[Ee]?[\\+\\-]?\\L*\\d*)?(\\[&.*?\\])"
         tree <- gsub(pattern, "\\1\\3\\2", tree)
     }
     #if (grepl("\\]:[0-9\\.eE+\\-]*\\[", tree) || grepl("\\]\\[", tree)) {

--- a/tests/testthat/test-beast.R
+++ b/tests/testthat/test-beast.R
@@ -31,10 +31,10 @@ test_that("write.beast output a valid beast file", {
 })
 
 
-xx <- "(a[&rate=1]:2,(b[&rate=1.1]:1,c[&rate=0.9]:1)[&rate=1]:1);\n(a[&rate=1]:2,(b[&rate=1.1]:1,c[&rate=0.9]:1)[&rate=1]:1);"
+xx <- "(a:2L[&rate=1],(b:[&rate=1.1]1L,c[&rate=0.9]:1):-10e-6[&rate=1]);\n(a[&rate=1]:2,(b[&rate=1.1]:1,c[&rate=0.9]:1)[&rate=1]:1);"
 
 tree1 <- structure(list(edge=matrix(c(4L, 4L, 5L, 5L, 1L, 5L, 2L, 3L), ncol=2),
-                        edge.length=c(2, 1, 1, 1),
+                        edge.length=c(2, -1e-05, 1, 1),
                         Nnode=2L,
                         tip.label=c("a", "b", "c")),
                         class="phylo",


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
the output of beast might have negative branch, which might cause the nodes to miss the metadata after run `read.beast`. 
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
> library(treeio)
> text <- '(a:2L[&rate=1],(b:[&rate=1.1]1L,c[&rate=0.9]:1):-10e-6[&rate=1]);'
> tr <- read.beast.newick(textConnection(text))
> tr
'treedata' S4 object'.

...@ phylo:

Phylogenetic tree with 3 tips and 2 internal nodes.

Tip labels:
  a, b, c

Rooted; includes branch lengths.

with the following features available:
  'rate'.

# The associated data tibble abstraction: 5 × 4
# The 'node', 'label' and 'isTip' are from the phylo tree.
   node label isTip  rate
  <int> <chr> <lgl> <dbl>
1     1 a     TRUE    1
2     2 b     TRUE    1.1
3     3 c     TRUE    0.9
4     4 NA    FALSE  NA
5     5 NA    FALSE   1
> tr %>% as_tibble()
# A tbl_tree abstraction: 5 × 5
# which can be converted to treedata or phylo
# via as.treedata or as.phylo
  parent  node branch.length label  rate
   <int> <int>         <dbl> <chr> <dbl>
1      4     1       2       a       1
2      5     2       1       b       1.1
3      5     3       1       c       0.9
4      4     4      NA       NA     NA
5      4     5      -0.00001 NA      1
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

