### PR TITLE
read.beast is not propagating the threading argument

### DIFF
--- a/R/beast.R
+++ b/R/beast.R
@@ -17,7 +17,7 @@ read.beast <- function(file, threads = 1, verbose = FALSE) {
     text <- readLines(file)
 
     treetext <- read.treetext_beast(text)
-    stats <- read.stats_beast(text, treetext, threads = 1, verbose = FALSE)
+    stats <- read.stats_beast(text, treetext, threads = threads, verbose = verbose)
     phylo <- read.nexus(file)
 
     if (length(treetext) == 1) {


### PR DESCRIPTION
`read.beast` can use mclapply to speed up tree processing, which is very helpful for large beast analyses. However, the `threads` argument does not get passed correctly, and is always set to 1 (and verbose is always set to FALSE). 

This PR fixes that.

